### PR TITLE
fix: update access control setup

### DIFF
--- a/contracts/AccessControlContract.sol
+++ b/contracts/AccessControlContract.sol
@@ -10,14 +10,29 @@ contract AccessControlContract is
 {
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant GRANTER_ROLE = keccak256("GRANTER_ROLE");
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
 
     function initialize() public initializer {
         __AccessControl_init();
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(ADMIN_ROLE, msg.sender);
         _grantRole(GRANTER_ROLE, msg.sender);
+        _grantRole(MINTER_ROLE, msg.sender);
 
         _setRoleAdmin(ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
         _setRoleAdmin(GRANTER_ROLE, ADMIN_ROLE);
+        _setRoleAdmin(MINTER_ROLE, ADMIN_ROLE);
+    }
+
+    function isAdmin(address account) external view returns (bool) {
+        return hasRole(ADMIN_ROLE, account);
+    }
+
+    function isGranter(address account) external view returns (bool) {
+        return hasRole(GRANTER_ROLE, account);
+    }
+
+    function isMinter(address account) external view returns (bool) {
+        return hasRole(MINTER_ROLE, account);
     }
 }

--- a/contracts/TokenContract.sol
+++ b/contracts/TokenContract.sol
@@ -2,30 +2,29 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "./AccessControlContract.sol";
 
 contract TokenContract is 
     Initializable,
-    ERC20Upgradeable,
-    AccessControlUpgradeable 
+    ERC20Upgradeable
 {
-    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    AccessControlContract private accessControl;
 
     function initialize(
         string memory name,
-        string memory symbol
+        string memory symbol,
+        address accessControlAddress
     ) public initializer {
         __ERC20_init(name, symbol);
-        __AccessControl_init();
-        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        _grantRole(MINTER_ROLE, msg.sender);
+        accessControl = AccessControlContract(accessControlAddress);
     }
 
     function mint(
         address to,
         uint256 amount
-    ) public onlyRole(MINTER_ROLE) {
+    ) public {
+        require(accessControl.isMinter(msg.sender), "Only minter can mint tokens");
         _mint(to, amount);
     }
 }


### PR DESCRIPTION
fix: Update access control setup in deployment script

- Gas optimisations
- Modify the `setupContracts` function to grant the `MINTER_ROLE` to the `VestingContract` using the `AccessControlContract`
- Update the `main` function to pass the `accessControlContract` to the `setupContracts` function
- Keep the access management solely in the `AccessControlContract` and grant necessary roles after deployment
- Use of unchecked blocks in the claimVestedTokens function to avoid unnecessary overflow/underflow checks when updating the claimedTokens and totalReleasedTokens.